### PR TITLE
[sdl] Turn tentative definition into actual definition.

### DIFF
--- a/code/sdl/sdl_glimp.c
+++ b/code/sdl/sdl_glimp.c
@@ -63,7 +63,7 @@ void (APIENTRYP qglMultiTexCoord2fARB) (GLenum target, GLfloat s, GLfloat t);
 void (APIENTRYP qglLockArraysEXT) (GLint first, GLsizei count);
 void (APIENTRYP qglUnlockArraysEXT) (void);
 
-#define GLE(ret, name, ...) name##proc * qgl##name;
+#define GLE(ret, name, ...) name##proc * qgl##name = NULL;
 QGL_1_1_PROCS;
 QGL_1_1_FIXED_FUNCTION_PROCS;
 QGL_DESKTOP_1_1_PROCS;


### PR DESCRIPTION
There is no need for a tentative definition in this case. By providing
an explicit initializer, the resulting definition has the same effect
as before, but is no longer tentative. This avoids easy errors
resulting from multiple tentative definitions in different translation
units. (Previous compilers permitted those common errors, but GCC 10
rejects them by default.)